### PR TITLE
Add missing single-quote

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -17,7 +17,7 @@
         <span data-ty="input">curl 'https://ec2.shop'</span>
         <span data-ty="input">curl 'https://ec2.shop?region=us-west-2'</span>
         <span data-ty="input">curl 'https://ec2.shop?region=us-west-2&filter=m4,m5,ssd'</span>
-        <span data-ty="input">curl 'https://ec2.shop -H 'accept: json'</span>
+        <span data-ty="input">curl 'https://ec2.shop' -H 'accept: json'</span>
       </div>
 
     </div>


### PR DESCRIPTION
Just a typo fix: The fourth curl example was missing a quote.