### PR TITLE
Fix Spot prices fetching for non-us regions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:sid-slim
 
+RUN apt-get -y update \
+ && apt-get -y upgrade \
+ && apt-get -y install ca-certificates
+
 WORKDIR /app
 
 #COPY data /app/data

--- a/price.go
+++ b/price.go
@@ -196,8 +196,7 @@ func (p *PriceFinder) PriceListFromRequest(c echo.Context) []*Price {
 		}
 
 		// Attempt to load spot price
-		region := requestRegion[0 : len(requestRegion)-2]
-		if _spotPrice, err := p.SpotPriceFinder.PriceForInstance(region, m.EC2InstanceType); err == nil {
+		if _spotPrice, err := p.SpotPriceFinder.PriceForInstance(requestRegion, m.EC2InstanceType); err == nil {
 			if _spotPrice != nil && _spotPrice.Linux != nil {
 				price.SpotPrice = *_spotPrice.Linux
 			}

--- a/spot.go
+++ b/spot.go
@@ -130,8 +130,27 @@ func (s *SpotPriceCrawler) Fetch() error {
 	return nil
 }
 
+func (s *SpotPriceCrawler) SpotRegionName(region string) string {
+	// The AWS API we're using has some funky names for some regions; e.g. eu-west-1 is referred to as eu-ireland
+	// This function maps an "actual" region name to the one in this API call
+	spotRegionMap := map[string]string{
+		"us-east-1": "us-east",
+		"us-west-1": "us-west",
+		"eu-west-1": "eu-ireland",
+		"ap-southeast-1": "apac-sin",
+		"ap-southeast-2": "apac-syd",
+		"ap-northeast-1": "apac-tokyo",
+	}
+	spotRegionName, found := spotRegionMap[region]
+	if found {
+		return spotRegionName
+	} else {
+		return region
+	}
+}
+
 func (s *SpotPriceCrawler) PriceForInstance(region string, instanceType string) (*SpotPrice, error) {
-	m := s.pricePerRegions[region][instanceType]
+	m := s.pricePerRegions[s.SpotRegionName(region)][instanceType]
 	if m == nil {
 		return nil, errors.New("Invalid instance type or region")
 	}


### PR DESCRIPTION
Hi @v9n 👋 

The API we're using for Spot Pricing uses non-standard region names,
like `eu-ireland` instead of `eu-west-1`.

This has been noticed during development as the region is looked up
truncated of its last two characters (`us-east-1` -> `us-east`), which
works for us-east and us-west, but no other region (and actively breaks
other conforming regions like `eu-west-2` :) ).

This commit fixes this by adding a map of "real region names" to the
ones that the API returns, so that we can retrieve the correct spot
prices across all regions.

Also, I've added the `ca-certificates` package to the Dockerfile to fix
the following error when running in Docker:
```
Error fetching spot price Get "https://website.spot.ec2.aws.a2z.com/spot.js": x509: certificate signed by unknown authority
```