### PR TITLE
New fields: Spot Savings, Spot Reclaim Rate

### DIFF
--- a/spot.go
+++ b/spot.go
@@ -10,12 +10,17 @@ import (
 )
 
 const (
-	AWSSpotPriceUrl = "https://website.spot.ec2.aws.a2z.com/spot.js"
+	AWSSpotPriceUrl       = "https://website.spot.ec2.aws.a2z.com/spot.js"
+	AWSSpotAdvisorDataUrl = "https://spot-bid-advisor.s3.amazonaws.com/spot-advisor-data.json"
 )
 
 type SpotPrice struct {
-	Linux *float64
-	MSWin *float64
+	Linux            *float64
+	LinuxSavings     *int
+	LinuxReclaimRate *int
+	MSWin            *float64
+	MSWinSavings     *int
+	MSWinReclaimRate *int
 }
 
 type SpotValueColumn struct {
@@ -44,6 +49,20 @@ type SpotPriceResponse struct {
 
 type SpotPriceResponseWrap struct {
 	Config *SpotPriceResponse `json:"config"`
+}
+
+type SpotInstanceTypeDetails struct {
+	Savings     int `json:"s"`
+	ReclaimRate int `json:"r"`
+}
+
+type SpotAdvisorRegion struct {
+	Windows map[string]*SpotInstanceTypeDetails `json:"Windows"`
+	Linux   map[string]*SpotInstanceTypeDetails `json:"Linux"`
+}
+
+type SpotAdvisorResponseWrap struct {
+	Regions map[string]*SpotAdvisorRegion `json:"spot_advisor"`
 }
 
 type SpotPriceCrawler struct {
@@ -95,11 +114,12 @@ func (s *SpotPriceCrawler) Fetch() error {
 	price := priceWrap.Config
 
 	for _, r := range price.Regions {
-		s.pricePerRegions[r.Region] = make(map[string]*SpotPrice)
+		region := s.SpotRegionName(r.Region)
+		s.pricePerRegions[region] = make(map[string]*SpotPrice)
 
 		for _, t := range r.InstanceTypes {
 			for _, size := range t.Sizes {
-				s.pricePerRegions[r.Region][size.Size] = &SpotPrice{}
+				s.pricePerRegions[region][size.Size] = &SpotPrice{}
 				for _, vc := range size.ValueColumns {
 					if vc.RawPrice.USD == "N/A*" {
 						continue
@@ -107,15 +127,15 @@ func (s *SpotPriceCrawler) Fetch() error {
 
 					if vc.Name == "linux" {
 						if v, err := vc.RawPrice.Price(); err == nil {
-							s.pricePerRegions[r.Region][size.Size].Linux = new(float64)
-							*s.pricePerRegions[r.Region][size.Size].Linux = v
+							s.pricePerRegions[region][size.Size].Linux = new(float64)
+							*s.pricePerRegions[region][size.Size].Linux = v
 						}
 					}
 
 					if vc.Name == "mswin" {
 						if v, err := vc.RawPrice.Price(); err == nil {
-							s.pricePerRegions[r.Region][size.Size].MSWin = new(float64)
-							*s.pricePerRegions[r.Region][size.Size].MSWin = v
+							s.pricePerRegions[region][size.Size].MSWin = new(float64)
+							*s.pricePerRegions[region][size.Size].MSWin = v
 						}
 					}
 				}
@@ -130,27 +150,75 @@ func (s *SpotPriceCrawler) Fetch() error {
 	return nil
 }
 
+func (s *SpotPriceCrawler) FetchSpotAdvisor() error {
+	t0 := time.Now()
+	resp, err := s.client.Get(AWSSpotAdvisorDataUrl)
+	if err != nil {
+		fmt.Println("Error fetching spot advisor data", err)
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Fail to read response body", err)
+		return err
+	}
+
+	var spotAdvisorWrap SpotAdvisorResponseWrap
+
+	err = json.Unmarshal(body, &spotAdvisorWrap)
+	if err != nil {
+		fmt.Println("Cannot parse json from spot request response", err)
+		return err
+	}
+
+	regions := spotAdvisorWrap.Regions
+
+	for region, instanceTypes := range regions {
+		fmt.Println("At region", region)
+		for instanceType, instanceDetails := range instanceTypes.Windows {
+			s.pricePerRegions[region][instanceType].MSWinSavings = new(int)
+			*s.pricePerRegions[region][instanceType].MSWinSavings = instanceDetails.Savings
+			s.pricePerRegions[region][instanceType].MSWinReclaimRate = new(int)
+			*s.pricePerRegions[region][instanceType].MSWinReclaimRate = instanceDetails.ReclaimRate + 1
+		}
+		for instanceType, instanceDetails := range instanceTypes.Linux {
+			s.pricePerRegions[region][instanceType].LinuxSavings = new(int)
+			*s.pricePerRegions[region][instanceType].LinuxSavings = instanceDetails.Savings
+			s.pricePerRegions[region][instanceType].LinuxReclaimRate = new(int)
+			*s.pricePerRegions[region][instanceType].LinuxReclaimRate = instanceDetails.ReclaimRate + 1
+		}
+	}
+
+	//fmt.Printf("Spot Price %+v", s.pricePerRegions)
+	fmt.Println("Fetched spot advisor data in", time.Now().Sub(t0), "at", time.Now())
+
+	return nil
+}
+
 func (s *SpotPriceCrawler) SpotRegionName(region string) string {
 	// The AWS API we're using has some funky names for some regions; e.g. eu-west-1 is referred to as eu-ireland
-	// This function maps an "actual" region name to the one in this API call
+	// This function maps region name from this API call to actual region names
 	spotRegionMap := map[string]string{
-		"us-east-1": "us-east",
-		"us-west-1": "us-west",
-		"eu-west-1": "eu-ireland",
-		"ap-southeast-1": "apac-sin",
-		"ap-southeast-2": "apac-syd",
-		"ap-northeast-1": "apac-tokyo",
+		"us-east":    "us-east-1",
+		"us-west":    "us-west-1",
+		"eu-ireland": "eu-west-1",
+		"apac-sin":   "ap-southeast-1",
+		"apac-syd":   "ap-southeast-2",
+		"apac-tokyo": "ap-northeast-1",
 	}
-	spotRegionName, found := spotRegionMap[region]
+	fixedRegionName, found := spotRegionMap[region]
 	if found {
-		return spotRegionName
+		return fixedRegionName
 	} else {
 		return region
 	}
 }
 
 func (s *SpotPriceCrawler) PriceForInstance(region string, instanceType string) (*SpotPrice, error) {
-	m := s.pricePerRegions[s.SpotRegionName(region)][instanceType]
+	m := s.pricePerRegions[region][instanceType]
 	if m == nil {
 		return nil, errors.New("Invalid instance type or region")
 	}
@@ -172,4 +240,5 @@ func (s *SpotPriceCrawler) Run() {
 		}
 	}()
 	s.Fetch()
+	s.FetchSpotAdvisor()
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -60,7 +60,9 @@ new gridjs.Grid({
           }
         }
       }
-    }
+    },
+    'Spot Savings',
+    'Spot Reclaim Rate'
   ],
 
   data: window._pricedata,

--- a/views/index.html
+++ b/views/index.html
@@ -80,6 +80,8 @@
             {{ $val.Price }},
             {{ printf "%.3f" $val.MonthlyPrice }},
             {{ printf "%-10s" $val.FormatSpotPrice }},
+            {{ printf "%-10s" $val.FormatSpotSavings }},
+            {{ printf "%-10s" $val.FormatSpotReclaimRate }},
           ],
         {{ end }}
       ]


### PR DESCRIPTION
Hi again @v9n 😄 

This time it's for new functionality: get the savings & reclaim rate for spot instances!

A bit of background – I wanted a way to compare spot prices vs. their reclaim rate. The data is available in various places, but never side-by-side (ugh), so I decided to patch it all up together here.

I'm not sure this is something you'd like to incorporate in ec2.shop itself, as it may start to make things a bit cramped, but I thought I'd send a PR anyway if this is of interest 👍 

Here's a screenshot of the feature in action:
<img width="1427" alt="Screenshot 2020-07-10 at 12 14 50" src="https://user-images.githubusercontent.com/344835/87148823-01939e80-c2a7-11ea-8024-8fb288e8a625.png">
